### PR TITLE
use bash from environment as executing shell.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 config_loglevel="error"
 if [ "x$npm_debug" = "x" ]; then


### PR DESCRIPTION
as some shells do not support using brace-expansion, we'd better explicitly use bash.