### PR TITLE
Update eslintrc template to eslint 1.0.0 rule set

### DIFF
--- a/templates/eslintrc
+++ b/templates/eslintrc
@@ -63,7 +63,7 @@
     "consistent-return": 2,
     "curly": [2, "all"],
     "default-case": 2,
-    "dot-notation": [0, {
+    "dot-notation": [2, {
       "allowKeywords": true
     }],
     "eqeqeq": 2,
@@ -78,7 +78,7 @@
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-fallthrough": 2,
-    "no-floating-decimal": 0,
+    "no-floating-decimal": 2,
     "no-implicit-coercion": [2, {
       "boolean": true,
       "number": true,
@@ -180,7 +180,7 @@
     "no-spaced-func": 2,
     "no-ternary": 0,
     "no-trailing-spaces": 2,
-    "no-underscore-dangle": 0,
+    "no-underscore-dangle": 1,
     "one-var": 2,
     "operator-assignment": 0,
     "padded-blocks": [1, "never"],
@@ -229,7 +229,7 @@
     "no-class-assign": 2,
     "no-const-assign": 2,
     "prefer-reflect": 1,
-    "prefer-reflect": 1,
+    "prefer-spread": 1,
     "require-yield": 2
   }
 }

--- a/templates/eslintrc
+++ b/templates/eslintrc
@@ -1,11 +1,9 @@
 {
   "env": {
-    "jquery": true,
     "browser": true,
     "node": true
   },
   "globals": {
-    "Model": false
   },
   "ecmaFeatures": {
     "arrowFunctions": true,
@@ -24,15 +22,15 @@
     "octalLiterals": true,
     "regexUFlag": true,
     "regexYFlag": true,
+    "restParams": true,
     "spread": true,
     "superInFunctions": true,
     "templateStrings": true,
     "unicodeCodePointEscapes": true,
-    "globalReturn": true,
-    "jsx": false
+    "globalReturn": true
   },
   "rules": {
-    "no-comma-dangle": 2,
+    "comma-dangle": 2,
     "no-cond-assign": [2, "except-parens"],
     "no-console": 1,
     "no-constant-condition": 2,
@@ -40,7 +38,7 @@
     "no-debugger": 1,
     "no-dupe-keys": 2,
     "no-empty": 2,
-    "no-empty-class": 2,
+    "no-empty-character-class": 2,
     "no-ex-assign": 2,
     "no-extra-boolean-cast": 2,
     "no-extra-parens": 1,
@@ -51,12 +49,12 @@
     "no-irregular-whitespace": 2,
     "no-obj-calls": 2,
     "no-regex-spaces": 2,
-    "no-reserved-keys": 2,
     "no-sparse-arrays": 2,
     "no-unreachable": 2,
     "use-isnan": 2,
     "valid-jsdoc": [2, {
-      "requireReturn": false
+      "requireReturn": false,
+      "requireReturnDescription": false
     }],
     "valid-typeof": 2,
 
@@ -65,7 +63,9 @@
     "consistent-return": 2,
     "curly": [2, "all"],
     "default-case": 2,
-    "dot-notation": [2, {"allowKeywords": true}],
+    "dot-notation": [0, {
+      "allowKeywords": true
+    }],
     "eqeqeq": 2,
     "guard-for-in": 1,
     "no-alert": 1,
@@ -78,8 +78,14 @@
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-fallthrough": 2,
-    "no-floating-decimal": 2,
+    "no-floating-decimal": 0,
+    "no-implicit-coercion": [2, {
+      "boolean": true,
+      "number": true,
+      "string": true
+    }],
     "no-implied-eval": 2,
+    "no-invalid-this": 2,
     "no-iterator": 2,
     "no-labels": 2,
     "no-lone-blocks": 2,
@@ -100,6 +106,7 @@
     "no-self-compare": 2,
     "no-sequences": 2,
     "no-unused-expressions": 2,
+    "no-useless-call": 2,
     "no-void": 2,
     "no-warning-comments": 1,
     "no-with": 2,
@@ -110,6 +117,7 @@
 
     "strict": [0, "never"],
 
+    "init-declarations": [1, "always"],
     "no-catch-shadow": 2,
     "no-delete-var": 2,
     "no-label-var": 2,
@@ -118,9 +126,13 @@
     "no-undef": 2,
     "no-undef-init": 2,
     "no-undefined": 2,
-    "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
+    "no-unused-vars": [2, {
+      "vars": "all",
+      "args": "after-used"
+    }],
     "no-use-before-define": [2, "nofunc"],
 
+    "callback-return": 2,
     "handle-callback-err": 1,
     "no-mixed-requires": 0,
     "no-new-require": 2,
@@ -130,15 +142,29 @@
     "no-sync": 0,
 
     "indent": [2, 2],
-    "brace-style": [2, "1tbs", { "allowSingleLine": false }],
+    "brace-style": [2, "1tbs", {
+      "allowSingleLine": false
+    }],
     "camelcase": 2,
-    "comma-spacing": [2, {"before": false, "after": true}],
+    "comma-spacing": [2, {
+      "before": false,
+      "after": true
+    }],
     "comma-style": [2, "last"],
     "consistent-this": [2, "none"],
     "eol-last": 1,
     "func-names": 0,
     "func-style": 0,
-    "key-spacing": [2, {"beforeColon": false, "afterColon": true}],
+    "id-length": [2, {
+      "min": 3
+    }],
+    "id-match": [2, "^[a-z]+([A-Z][a-z]+)*$", {
+      "properties": true
+    }],
+    "key-spacing": [2, {
+      "beforeColon": false,
+      "afterColon": true
+    }],
     "max-nested-callbacks": [2, 3],
     "new-cap": 2,
     "new-parens": 2,
@@ -146,41 +172,64 @@
     "no-inline-comments": 0,
     "no-lonely-if": 2,
     "no-mixed-spaces-and-tabs": 2,
-    "no-multiple-empty-lines": [1, {"max": 1}],
+    "no-multiple-empty-lines": [1, {
+      "max": 1
+    }],
     "no-nested-ternary": 2,
     "no-new-object": 2,
-    "no-space-before-semi": 2,
     "no-spaced-func": 2,
     "no-ternary": 0,
     "no-trailing-spaces": 2,
-    "no-underscore-dangle": 1,
-    "no-wrap-func": 2,
+    "no-underscore-dangle": 0,
     "one-var": 2,
     "operator-assignment": 0,
     "padded-blocks": [1, "never"],
-    "quote-props": [2, "as-needed"],
+    "quote-props": [0, "as-needed", {
+      "keywords": false
+    }],
     "quotes": [2, "single", "avoid-escape"],
     "semi": [2, "always"],
+    "semi-spacing": [2, {
+      "before": false,
+      "after": true
+    }],
     "sort-vars": 0,
-    "space-after-function-name": [2, "never"],
+    "space-before-function-paren": [2, "never"],
     "space-after-keywords": [2, "always"],
     "space-before-blocks": [2, "always"],
-    "space-in-brackets": [1, "never"],
     "space-in-parens": [2, "never"],
     "space-infix-ops": 2,
     "space-return-throw-case": 2,
-    "space-unary-ops": [2, { "words": true, "nonwords": false }],
-    "spaced-line-comment": [2, "always"],
+    "space-unary-ops": [2, {
+      "words": true,
+      "nonwords": false
+    }],
+    "spaced-comment": [2, "always"],
+    "object-curly-spacing": [1, "never"],
+    "array-bracket-spacing": [1, "never"],
     "wrap-regex": 0,
 
     "no-var": 0,
-    "generator-star": [2, "end"],
+    "generator-star-spacing": [2, {
+      "before": true,
+      "after": false
+    }],
 
     "max-depth": [1, 3],
     "max-len": [2, 80, 2],
     "max-params": [2, 4],
     "max-statements": [1, 15],
     "no-bitwise": 2,
-    "no-plusplus": 0
+    "no-plusplus": 0,
+    "arrow-parens": [1, "as-needed"],
+    "arrow-spacing": [2, {
+      "before": true,
+      "after": true
+    }],
+    "no-class-assign": 2,
+    "no-const-assign": 2,
+    "prefer-reflect": 1,
+    "prefer-reflect": 1,
+    "require-yield": 2
   }
 }


### PR DESCRIPTION
Some options are expected to change. 

`id-match` for example is to strict and must be adjusted as needed. 