### PR TITLE
proposal(eslintrc): warn for arrow-parens rule

### DIFF
--- a/templates/eslintrc
+++ b/templates/eslintrc
@@ -247,7 +247,7 @@
     "no-class-assign": 2,
     "no-const-assign": 2,
     "arrow-body-style": [1, "as-needed"],
-    "arrow-parens": 0,
+    "arrow-parens": [1, "as-needed"],
     "constructor-super": 2,
     "no-confusing-arrow": 1,
     "no-dupe-class-members": 2,


### PR DESCRIPTION
Does anyone remember why we set this to `0`? Please discuss.