### PR TITLE
feat(eslintrc): allow space before function paren for async functions

### DIFF
--- a/templates/eslintrc
+++ b/templates/eslintrc
@@ -312,8 +312,12 @@
     ],
     "sort-vars": 0,
     "space-before-function-paren": [
-      2,
-      "never"
+      "error",
+      {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+      }
     ],
     "keyword-spacing": [
       "error",


### PR DESCRIPTION
This currently causes an error because of the `async` keyword:

```js
  const someFunct = async () => return 'ubilabs';
```

The PR aims to fix this.